### PR TITLE
Fix NameError for 'table' for string joins

### DIFF
--- a/lib/join_dependency.rb
+++ b/lib/join_dependency.rb
@@ -38,7 +38,7 @@ module JoinDependency
       string_joins              = buckets[:string_join].map(&:strip).uniq
 
       joins = string_joins.map do |join|
-        table.create_string_join(Are.sql(join)) unless join.blank?
+        relation.table.create_string_join(Arel.sql(join)) unless join.blank?
       end.compact
 
       join_list =

--- a/spec/join_dependency_spec.rb
+++ b/spec/join_dependency_spec.rb
@@ -11,9 +11,11 @@ RSpec.describe JoinDependency do
   end
 
   it "can convert a relation to a join dependency" do
-    relation = Post.joins(:author)
-    jd = JoinDependency.from_relation(relation)
-    expect(jd).to be_an(ActiveRecord::Associations::JoinDependency)
+    [:author, 'author'].each do |join_dep|
+      relation = Post.joins(:author)
+      jd = JoinDependency.from_relation(relation)
+      expect(jd).to be_an(ActiveRecord::Associations::JoinDependency)
+    end
   end
 
   it "includes association join children" do


### PR DESCRIPTION
The PR resolving #2 introduced an issue where a string join would raise a NameError. This PR resolves the issue and adds coverage for it. 